### PR TITLE
Add json key case rule

### DIFF
--- a/src/commonMain/kotlin/jp/nephy/jsonkt/delegation/EnumProperty.kt
+++ b/src/commonMain/kotlin/jp/nephy/jsonkt/delegation/EnumProperty.kt
@@ -84,7 +84,7 @@ inline fun <reified T: Any, reified E> JsonObject.byEnum(
 inline fun <reified T: Any, reified E> JsonModel.enum(
     key: String? = null,
     crossinline default: JsonObjectDefaultSelector<E>
-) where E: Enum<E>, E: JsonEnum<T> = json.jsonObjectProperty(key, default) {
+) where E: Enum<E>, E: JsonEnum<T> = jsonObjectProperty(key, default) {
     val casted = it.primitive.cast<T>()
 
     findEnumMember(casted)
@@ -92,7 +92,7 @@ inline fun <reified T: Any, reified E> JsonModel.enum(
 
 inline fun <reified T: Any, reified E> JsonModel.enum(
     key: String? = null
-) where E: Enum<E>, E: JsonEnum<T> = json.jsonObjectProperty(key) {
+) where E: Enum<E>, E: JsonEnum<T> = jsonObjectProperty(key) {
     val casted = it.primitive.cast<T>()
 
     findEnumMember<T, E>(casted)
@@ -122,7 +122,7 @@ inline fun <reified T: Any, reified E> JsonObject.byNullableEnum(
 inline fun <reified T: Any, reified E> JsonModel.nullableEnum(
     key: String? = null,
     crossinline default: JsonObjectDefaultSelector<E?>
-) where E: Enum<E>, E: JsonEnum<T> = json.jsonObjectProperty(key, default) {
+) where E: Enum<E>, E: JsonEnum<T> = jsonObjectProperty(key, default) {
     val casted = it.primitive.cast<T>()
 
     findEnumMemberOrNull(casted)
@@ -130,7 +130,7 @@ inline fun <reified T: Any, reified E> JsonModel.nullableEnum(
 
 inline fun <reified T: Any, reified E> JsonModel.nullableEnum(
     key: String? = null
-) where E: Enum<E>, E: JsonEnum<T> = json.jsonObjectProperty(key) {
+) where E: Enum<E>, E: JsonEnum<T> = jsonObjectProperty(key) {
     val casted = it.primitive.cast<T>()
 
     findEnumMemberOrNull<T, E>(casted)
@@ -139,7 +139,7 @@ inline fun <reified T: Any, reified E> JsonModel.nullableEnum(
 inline fun <reified T: Any, reified E> JsonModel.enumOrNull(
     key: String? = null,
     crossinline default: JsonObjectDefaultSelector<E?>
-) where E: Enum<E>, E: JsonEnum<T> = json.jsonObjectProperty(key, default) {
+) where E: Enum<E>, E: JsonEnum<T> = jsonObjectProperty(key, default) {
     val casted = it.primitive.cast<T>()
 
     findEnumMemberOrNull(casted)
@@ -147,7 +147,7 @@ inline fun <reified T: Any, reified E> JsonModel.enumOrNull(
 
 inline fun <reified T: Any, reified E> JsonModel.enumOrNull(
     key: String? = null
-) where E: Enum<E>, E: JsonEnum<T> = json.jsonObjectProperty(key) {
+) where E: Enum<E>, E: JsonEnum<T> = jsonObjectProperty(key) {
     val casted = it.primitive.cast<T>()
 
     findEnumMemberOrNull<T, E>(casted)
@@ -177,7 +177,7 @@ inline fun <reified T: Any, reified E> JsonObject.byEnumList(
 inline fun <reified T: Any, reified E> JsonModel.enumList(
     key: String? = null,
     crossinline default: JsonArrayDefaultSelector<E>
-) where E: Enum<E>, E: JsonEnum<T> = json.jsonArrayProperty(key, default) {
+) where E: Enum<E>, E: JsonEnum<T> = jsonArrayProperty(key, default) {
     val casted = it.primitive.cast<T>()
 
     findEnumMember(casted)
@@ -185,7 +185,7 @@ inline fun <reified T: Any, reified E> JsonModel.enumList(
 
 inline fun <reified T: Any, reified E> JsonModel.enumList(
     key: String? = null
-) where E: Enum<E>, E: JsonEnum<T> = json.jsonArrayProperty(key) {
+) where E: Enum<E>, E: JsonEnum<T> = jsonArrayProperty(key) {
     val casted = it.primitive.cast<T>()
 
     findEnumMember<T, E>(casted)
@@ -215,7 +215,7 @@ inline fun <reified T: Any, reified E> JsonObject.byNullableEnumList(
 inline fun <reified T: Any, reified E> JsonModel.nullableEnumList(
     key: String? = null,
     crossinline default: JsonArrayDefaultSelector<E?>
-) where E: Enum<E>, E: JsonEnum<T> = json.jsonArrayProperty(key, default) {
+) where E: Enum<E>, E: JsonEnum<T> = jsonArrayProperty(key, default) {
     val casted = it.primitive.cast<T>()
 
     findEnumMemberOrNull(casted)
@@ -223,7 +223,7 @@ inline fun <reified T: Any, reified E> JsonModel.nullableEnumList(
 
 inline fun <reified T: Any, reified E> JsonModel.nullableEnumList(
     key: String? = null
-) where E: Enum<E>, E: JsonEnum<T> = json.jsonArrayProperty(key) {
+) where E: Enum<E>, E: JsonEnum<T> = jsonArrayProperty(key) {
     val casted = it.primitive.cast<T>()
 
     findEnumMemberOrNull<T, E>(casted)

--- a/src/commonMain/kotlin/jp/nephy/jsonkt/delegation/JsonModel.kt
+++ b/src/commonMain/kotlin/jp/nephy/jsonkt/delegation/JsonModel.kt
@@ -1,7 +1,70 @@
+/*
+ * The MIT License (MIT)
+ *
+ *     Copyright (c) 2017-2019 Nephy Project Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package jp.nephy.jsonkt.delegation
 
 import jp.nephy.jsonkt.JsonObject
+import kotlin.reflect.KProperty
+
+typealias JsonKeyConverter = (KProperty<*>) -> String
 
 interface JsonModel {
     val json: JsonObject
+
+    val keyCase: JsonKeyCase
+        get() = JsonKeyCase.Unspecified
+
+    val keyConverter: JsonKeyConverter
+        get() = ::defaultJsonKeyConverter
+}
+
+private fun JsonModel.defaultJsonKeyConverter(property: KProperty<*>): String {
+    return when (keyCase) {
+        JsonKeyCase.Unspecified -> property.name
+        JsonKeyCase.LowerCamelCase -> {
+            property.name.decapitalize()
+        }
+        JsonKeyCase.UpperCamelCase -> {
+            property.name.capitalize()
+        }
+        JsonKeyCase.SnakeCase -> {
+            buildString {
+                for (c in property.name) {
+                    if (c == c.toUpperCase()) {
+                        if (length > 0) {
+                            append('_')
+                        }
+                        append(c.toLowerCase())
+                    } else {
+                        append(c)
+                    }
+                }
+            }
+        }
+    }
+}
+
+enum class JsonKeyCase {
+    Unspecified, LowerCamelCase, UpperCamelCase, SnakeCase
 }

--- a/src/commonMain/kotlin/jp/nephy/jsonkt/delegation/LambdaProperty.kt
+++ b/src/commonMain/kotlin/jp/nephy/jsonkt/delegation/LambdaProperty.kt
@@ -53,18 +53,18 @@ inline fun <T: Any> JsonModel.lambda(
     key: String? = null,
     crossinline default: JsonObjectDefaultSelector<T>,
     crossinline converter: JsonElementConverter<T>
-) = json.jsonObjectProperty(key, default, converter)
+) = jsonObjectProperty(key, default, converter)
 
 inline fun <T: Any> JsonModel.lambda(
     key: String? = null,
     default: T,
     crossinline converter: JsonElementConverter<T>
-) = json.jsonObjectProperty(key, { default }, converter)
+) = jsonObjectProperty(key, { default }, converter)
 
 inline fun <T: Any> JsonModel.lambda(
     key: String? = null,
     crossinline converter: JsonElementConverter<T>
-) = json.jsonObjectProperty(key, converter = converter)
+) = jsonObjectProperty(key, converter = converter)
 
 /*
  *  T?
@@ -91,18 +91,18 @@ inline fun <T> JsonModel?.nullableLambda(
     key: String? = null,
     crossinline default: JsonObjectDefaultSelector<T?>,
     crossinline converter: JsonElementConverter<T?>
-) = this?.json.jsonObjectProperty(key, default, converter)
+) = jsonObjectProperty(key, default, converter)
 
 inline fun <T> JsonModel?.nullableLambda(
     key: String? = null,
     default: T?,
     crossinline converter: JsonElementConverter<T?>
-) = this?.json.jsonObjectProperty(key, { default }, converter)
+) = jsonObjectProperty(key, { default }, converter)
 
 inline fun <T> JsonModel?.nullableLambda(
     key: String? = null,
     crossinline converter: JsonElementConverter<T?>
-) = this?.json.jsonObjectProperty(key, converter = converter)
+) = jsonObjectProperty(key, converter = converter)
 
 /*
  *  List<T>
@@ -129,18 +129,18 @@ inline fun <T: Any> JsonModel.lambdaList(
     key: String? = null,
     crossinline default: JsonArrayDefaultSelector<T>,
     crossinline converter: JsonElementConverter<T>
-) = json.jsonArrayProperty(key, default, converter)
+) = jsonArrayProperty(key, default, converter)
 
 inline fun <T: Any> JsonModel.lambdaList(
     key: String? = null,
     default: List<T>,
     crossinline converter: JsonElementConverter<T>
-) = json.jsonArrayProperty(key, { default }, converter)
+) = jsonArrayProperty(key, { default }, converter)
 
 inline fun <T: Any> JsonModel.lambdaList(
     key: String? = null,
     crossinline converter: JsonElementConverter<T>
-) = json.jsonArrayProperty(key, converter = converter)
+) = jsonArrayProperty(key, converter = converter)
 
 /*
  *  List<T?>
@@ -167,15 +167,15 @@ inline fun <T> JsonModel?.nullableLambdaList(
     key: String? = null,
     crossinline default: JsonArrayDefaultSelector<T?>,
     crossinline converter: JsonElementConverter<T?>
-) = this?.json.jsonArrayProperty(key, default, converter)
+) = jsonArrayProperty(key, default, converter)
 
 inline fun <T> JsonModel?.nullableLambdaList(
     key: String? = null,
     default: List<T?>,
     crossinline converter: JsonElementConverter<T?>
-) = this?.json.jsonArrayProperty(key, { default }, converter)
+) = jsonArrayProperty(key, { default }, converter)
 
 inline fun <T> JsonModel?.nullableLambdaList(
     key: String? = null,
     crossinline converter: JsonElementConverter<T?>
-) = this?.json.jsonArrayProperty(key, converter = converter)
+) = jsonArrayProperty(key, converter = converter)

--- a/src/commonMain/kotlin/jp/nephy/jsonkt/delegation/MapProperty.kt
+++ b/src/commonMain/kotlin/jp/nephy/jsonkt/delegation/MapProperty.kt
@@ -29,8 +29,17 @@ package jp.nephy.jsonkt.delegation
 import kotlinx.serialization.json.JsonObject
 import kotlin.reflect.KProperty
 
-expect inline operator fun <reified T> JsonObject.getValue(thisRef: Any?, property: KProperty<*>): T
+@PublishedApi
+internal expect inline fun <reified T> JsonObject.getValue(key: String): T
+
+inline operator fun <reified T> JsonObject.getValue(thisRef: Any?, property: KProperty<*>): T {
+    val jsonKey = property.name
+
+    return getValue(jsonKey)
+}
 
 inline operator fun <reified T> JsonModel.getValue(thisRef: Any?, property: KProperty<*>): T {
-    return json.getValue(thisRef, property)
+    val jsonKey = keyConverter(property)
+
+    return json.getValue(jsonKey)
 }

--- a/src/commonTest/kotlin/SampleJson.kt
+++ b/src/commonTest/kotlin/SampleJson.kt
@@ -20,5 +20,6 @@ const val json = """{
             "y": 20.00001,
             "z": 30
         }
-    ]
+    ],
+    "snake_key": "Python"
 }"""

--- a/src/jsMain/kotlin/jp/nephy/jsonkt/delegation/MapPropertyJS.kt
+++ b/src/jsMain/kotlin/jp/nephy/jsonkt/delegation/MapPropertyJS.kt
@@ -8,11 +8,11 @@ import kotlinx.serialization.json.JsonLiteral
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlin.reflect.KProperty
 
+@PublishedApi
 @Suppress("IMPLICIT_CAST_TO_ANY", "UNCHECKED_CAST")
-actual inline operator fun <reified T> JsonObject.getValue(thisRef: Any?, property: KProperty<*>): T {
-    val value = this[property.name]
+internal actual inline fun <reified T> JsonObject.getValue(key: String): T {
+    val value = this[key]
 
     return when (val kClass = T::class) {
         Boolean::class -> {

--- a/src/jvmMain/kotlin/jp.nephy/jsonkt/delegation/MapPropertyJVM.kt
+++ b/src/jvmMain/kotlin/jp.nephy/jsonkt/delegation/MapPropertyJVM.kt
@@ -27,10 +27,6 @@
 package jp.nephy.jsonkt.delegation
 
 import jp.nephy.jsonkt.*
-import jp.nephy.jsonkt.jsonArrayOrNull
-import jp.nephy.jsonkt.jsonObjectOrNull
-import jp.nephy.jsonkt.primitiveOrNull
-import jp.nephy.jsonkt.stringOrNull
 import kotlinx.serialization.json.*
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -39,12 +35,12 @@ import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlin.reflect.KClass
-import kotlin.reflect.KProperty
 import kotlin.reflect.full.isSubclassOf
 
+@PublishedApi
 @Suppress("IMPLICIT_CAST_TO_ANY", "UNCHECKED_CAST")
-actual inline operator fun <reified T> JsonObject.getValue(thisRef: Any?, property: KProperty<*>): T {
-    val value = this[property.name]
+internal actual inline fun <reified T> JsonObject.getValue(key: String): T {
+    val value = this[key]
 
     return when (val kClass = T::class) {
         Boolean::class -> {

--- a/src/jvmMain/kotlin/jp.nephy/jsonkt/delegation/ModelProperty.kt
+++ b/src/jvmMain/kotlin/jp.nephy/jsonkt/delegation/ModelProperty.kt
@@ -46,6 +46,16 @@ internal inline fun <reified T: JsonModel> JsonObject?.jsonModelOrDefaultPropert
 @PublishedApi
 internal inline fun <reified T: JsonModel> JsonObject?.jsonModelOrNullProperty(key: String? = null, vararg args: Any?) = jsonObjectProperty(key) { it.parseOrNull<T>(*args) }
 
+@PublishedApi
+internal inline fun <reified T: JsonModel> JsonModel?.jsonModelProperty(key: String? = null, vararg args: Any?) = jsonObjectProperty(key) { it.parse<T>(*args) }
+
+@PublishedApi
+internal inline fun <reified T: JsonModel> JsonModel?.jsonModelOrDefaultProperty(key: String? = null, vararg args: Any?) = jsonObjectProperty(key) { it.parseOrNull<T>(*args) ?: jsonObjectOf().parse(*args) }
+
+@PublishedApi
+internal inline fun <reified T: JsonModel> JsonModel?.jsonModelOrNullProperty(key: String? = null, vararg args: Any?) = jsonObjectProperty(key) { it.parseOrNull<T>(*args) }
+
+
 /**
  * @throws InvalidJsonModelException
  * @throws JsonCastException
@@ -59,25 +69,34 @@ internal inline fun <reified T: JsonModel> JsonObject?.jsonModelOrDefaultPropert
 @PublishedApi
 internal inline fun <reified T: JsonModel> JsonObject?.jsonModelOrNullProperty(key: String? = null) = jsonObjectProperty(key) { it.parseOrNull<T>() }
 
+@PublishedApi
+internal inline fun <reified T: JsonModel> JsonModel?.jsonModelProperty(key: String? = null) = jsonObjectProperty(key) { it.parse<T>() }
+
+@PublishedApi
+internal inline fun <reified T: JsonModel> JsonModel?.jsonModelOrDefaultProperty(key: String? = null) = jsonObjectProperty(key) { it.parseOrNull<T>() ?: jsonObjectOf().parse() }
+
+@PublishedApi
+internal inline fun <reified T: JsonModel> JsonModel?.jsonModelOrNullProperty(key: String? = null) = jsonObjectProperty(key) { it.parseOrNull<T>() }
+
 /*
     JsonModel
  */
 
 inline fun <reified T: JsonModel> JsonObject.byModel(key: String? = null, vararg args: Any?) = jsonModelProperty<T>(key, *args)
 
-inline fun <reified T: JsonModel> JsonModel.model(key: String? = null, vararg args: Any?) = json.jsonModelProperty<T>(key, *args)
+inline fun <reified T: JsonModel> JsonModel.model(key: String? = null, vararg args: Any?) = jsonModelProperty<T>(key, *args)
 
 inline fun <reified T: JsonModel> JsonObject.byModelOrDefault(key: String? = null, vararg args: Any?) = jsonModelOrDefaultProperty<T>(key, *args)
 
-inline fun <reified T: JsonModel> JsonModel.modelOrDefault(key: String? = null, vararg args: Any?) = json.jsonModelOrDefaultProperty<T>(key, *args)
+inline fun <reified T: JsonModel> JsonModel.modelOrDefault(key: String? = null, vararg args: Any?) = jsonModelOrDefaultProperty<T>(key, *args)
 
 inline fun <reified T: JsonModel> JsonObject.byModel(key: String? = null) = jsonModelProperty<T>(key)
 
-inline fun <reified T: JsonModel> JsonModel.model(key: String? = null) = json.jsonModelProperty<T>(key)
+inline fun <reified T: JsonModel> JsonModel.model(key: String? = null) = jsonModelProperty<T>(key)
 
 inline fun <reified T: JsonModel> JsonObject.byModelOrDefault(key: String? = null) = jsonModelOrDefaultProperty<T>(key)
 
-inline fun <reified T: JsonModel> JsonModel.modelOrDefault(key: String? = null) = json.jsonModelOrDefaultProperty<T>(key)
+inline fun <reified T: JsonModel> JsonModel.modelOrDefault(key: String? = null) = jsonModelOrDefaultProperty<T>(key)
 
 /*
     JsonModel?
@@ -85,32 +104,55 @@ inline fun <reified T: JsonModel> JsonModel.modelOrDefault(key: String? = null) 
 
 inline fun <reified T: JsonModel> JsonObject?.byNullableModel(key: String? = null, vararg args: Any?) = jsonModelOrNullProperty<T>(key, *args)
 
-inline fun <reified T: JsonModel> JsonModel.nullableModel(key: String? = null, vararg args: Any?) = json.jsonModelOrNullProperty<T>(key, *args)
+inline fun <reified T: JsonModel> JsonModel.nullableModel(key: String? = null, vararg args: Any?) = jsonModelOrNullProperty<T>(key, *args)
 
 inline fun <reified T: JsonModel> JsonObject?.byNullableModel(key: String? = null) = jsonModelOrNullProperty<T>(key)
 
-inline fun <reified T: JsonModel> JsonModel.nullableModel(key: String? = null) = json.jsonModelOrNullProperty<T>(key)
+inline fun <reified T: JsonModel> JsonModel.nullableModel(key: String? = null) = jsonModelOrNullProperty<T>(key)
 
 /**
  * @throws InvalidJsonModelException
  * @throws JsonCastException
  */
-inline fun <reified T: JsonModel> JsonObject?.jsonModelListProperty(key: String? = null, vararg args: Any?) = jsonArrayProperty(key) { it.parse<T>(*args) }
+@PublishedApi
+internal inline fun <reified T: JsonModel> JsonObject?.jsonModelListProperty(key: String? = null, vararg args: Any?) = jsonArrayProperty(key) { it.parse<T>(*args) }
 
-inline fun <reified T: JsonModel> JsonObject?.jsonModelListOrDefaultProperty(key: String? = null, vararg args: Any?) = jsonArrayProperty(key) { it.parseOrNull<T>(*args) ?: jsonObjectOf().parse(*args) }
+@PublishedApi
+internal inline fun <reified T: JsonModel> JsonObject?.jsonModelListOrDefaultProperty(key: String? = null, vararg args: Any?) = jsonArrayProperty(key) { it.parseOrNull<T>(*args) ?: jsonObjectOf().parse(*args) }
 
-inline fun <reified T: JsonModel> JsonObject?.jsonModelListOrNullProperty(key: String? = null, vararg args: Any?) = jsonArrayProperty(key) { it.parseOrNull<T>(*args) }
+@PublishedApi
+internal inline fun <reified T: JsonModel> JsonObject?.jsonModelListOrNullProperty(key: String? = null, vararg args: Any?) = jsonArrayProperty(key) { it.parseOrNull<T>(*args) }
+
+@PublishedApi
+internal inline fun <reified T: JsonModel> JsonModel?.jsonModelListProperty(key: String? = null, vararg args: Any?) = jsonArrayProperty(key) { it.parse<T>(*args) }
+
+@PublishedApi
+internal inline fun <reified T: JsonModel> JsonModel?.jsonModelListOrDefaultProperty(key: String? = null, vararg args: Any?) = jsonArrayProperty(key) { it.parseOrNull<T>(*args) ?: jsonObjectOf().parse(*args) }
+
+@PublishedApi
+internal inline fun <reified T: JsonModel> JsonModel?.jsonModelListOrNullProperty(key: String? = null, vararg args: Any?) = jsonArrayProperty(key) { it.parseOrNull<T>(*args) }
 
 /**
  * @throws InvalidJsonModelException
  * @throws JsonCastException
  */
-inline fun <reified T: JsonModel> JsonObject?.jsonModelListProperty(key: String? = null) = jsonArrayProperty(key) { it.parse<T>() }
+@PublishedApi
+internal inline fun <reified T: JsonModel> JsonObject?.jsonModelListProperty(key: String? = null) = jsonArrayProperty(key) { it.parse<T>() }
 
-inline fun <reified T: JsonModel> JsonObject?.jsonModelListOrDefaultProperty(key: String? = null) = jsonArrayProperty(key) { it.parseOrNull<T>() ?: jsonObjectOf().parse() }
+@PublishedApi
+internal inline fun <reified T: JsonModel> JsonObject?.jsonModelListOrDefaultProperty(key: String? = null) = jsonArrayProperty(key) { it.parseOrNull<T>() ?: jsonObjectOf().parse() }
 
-inline fun <reified T: JsonModel> JsonObject?.jsonModelListOrNullProperty(key: String? = null) = jsonArrayProperty(key) { it.parseOrNull<T>() }
+@PublishedApi
+internal inline fun <reified T: JsonModel> JsonObject?.jsonModelListOrNullProperty(key: String? = null) = jsonArrayProperty(key) { it.parseOrNull<T>() }
 
+@PublishedApi
+internal inline fun <reified T: JsonModel> JsonModel?.jsonModelListProperty(key: String? = null) = jsonArrayProperty(key) { it.parse<T>() }
+
+@PublishedApi
+internal inline fun <reified T: JsonModel> JsonModel?.jsonModelListOrDefaultProperty(key: String? = null) = jsonArrayProperty(key) { it.parseOrNull<T>() ?: jsonObjectOf().parse() }
+
+@PublishedApi
+internal inline fun <reified T: JsonModel> JsonModel?.jsonModelListOrNullProperty(key: String? = null) = jsonArrayProperty(key) { it.parseOrNull<T>() }
 
 /*
     List<JsonModel>
@@ -118,19 +160,19 @@ inline fun <reified T: JsonModel> JsonObject?.jsonModelListOrNullProperty(key: S
 
 inline fun <reified T: JsonModel> JsonObject.byModelList(key: String? = null, vararg args: Any?) = jsonModelListProperty<T>(key, *args)
 
-inline fun <reified T: JsonModel> JsonModel.modelList(key: String? = null, vararg args: Any?) = json.jsonModelListProperty<T>(key, *args)
+inline fun <reified T: JsonModel> JsonModel.modelList(key: String? = null, vararg args: Any?) = jsonModelListProperty<T>(key, *args)
 
 inline fun <reified T: JsonModel> JsonObject.byModelListOrDefault(key: String? = null, vararg args: Any?) = jsonModelListOrDefaultProperty<T>(key, *args)
 
-inline fun <reified T: JsonModel> JsonModel.modelListOrDefault(key: String? = null, vararg args: Any?) = json.jsonModelListOrDefaultProperty<T>(key, *args)
+inline fun <reified T: JsonModel> JsonModel.modelListOrDefault(key: String? = null, vararg args: Any?) = jsonModelListOrDefaultProperty<T>(key, *args)
 
 inline fun <reified T: JsonModel> JsonObject.byModelList(key: String? = null) = jsonModelListProperty<T>(key)
 
-inline fun <reified T: JsonModel> JsonModel.modelList(key: String? = null) = json.jsonModelListProperty<T>(key)
+inline fun <reified T: JsonModel> JsonModel.modelList(key: String? = null) = jsonModelListProperty<T>(key)
 
 inline fun <reified T: JsonModel> JsonObject.byModelListOrDefault(key: String? = null) = jsonModelListOrDefaultProperty<T>(key)
 
-inline fun <reified T: JsonModel> JsonModel.modelListOrDefault(key: String? = null) = json.jsonModelListOrDefaultProperty<T>(key)
+inline fun <reified T: JsonModel> JsonModel.modelListOrDefault(key: String? = null) = jsonModelListOrDefaultProperty<T>(key)
 
 
 /*
@@ -139,8 +181,8 @@ inline fun <reified T: JsonModel> JsonModel.modelListOrDefault(key: String? = nu
 
 inline fun <reified T: JsonModel> JsonObject?.byNullableModelList(key: String? = null, vararg args: Any?) = jsonModelListOrNullProperty<T>(key, *args)
 
-inline fun <reified T: JsonModel> JsonModel.nullableModelList(key: String? = null, vararg args: Any?) = json.jsonModelListOrNullProperty<T>(key, *args)
+inline fun <reified T: JsonModel> JsonModel.nullableModelList(key: String? = null, vararg args: Any?) = jsonModelListOrNullProperty<T>(key, *args)
 
 inline fun <reified T: JsonModel> JsonObject?.byNullableModelList(key: String? = null) = jsonModelListOrNullProperty<T>(key)
 
-inline fun <reified T: JsonModel> JsonModel.nullableModelList(key: String? = null) = json.jsonModelListOrNullProperty<T>(key)
+inline fun <reified T: JsonModel> JsonModel.nullableModelList(key: String? = null) = jsonModelListOrNullProperty<T>(key)

--- a/src/jvmTest/kotlin/SampleModel.kt
+++ b/src/jvmTest/kotlin/SampleModel.kt
@@ -4,12 +4,17 @@ import jp.nephy.jsonkt.JsonObject
 import jp.nephy.jsonkt.delegation.*
 
 data class Model(override val json: JsonObject): JsonModel {
+    override val keyCase: JsonKeyCase
+        get() = JsonKeyCase.SnakeCase
+
     val a by int
     val b by float
     val c by string
     val d by intList
     val e by model<E>()
     val f by modelList<E>()
+
+    val snakeKey by string
 
     data class E(override val json: JsonObject): JsonModel {
         val x by nullableString


### PR DESCRIPTION
`JsonModel` に `JsonKeyCase` を追加し, モデルクラスのプロパティ名と Json 側のキーとの相互変換を容易にしました。

現在, Lower Camel Case, Upper Camel Case, Snake Case への変換が実装されています。

```kotlin
class Model(override val json: JsonObject): JsonModel {
    override val keyCase = JsonKeyCase.SnakeCase

    val snakeKey by string
}

fun main() {
    val json = """{
        "snake_key": "Python"
    }"""
    val obj = json.parse<Model>()

    println(obj.snakeKey == "Python") // true
}
```